### PR TITLE
Improved error message

### DIFF
--- a/flask_restful/reqparse.py
+++ b/flask_restful/reqparse.py
@@ -189,10 +189,10 @@ class Argument(object):
                     if self.choices and value not in self.choices:
                         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:
                             return self.handle_validation_error(
-                                ValueError(u"{0} is not a valid choice".format(
+                                ValueError(u"{0!r} is not a valid choice".format(
                                     value)), bundle_errors)
                         self.handle_validation_error(
-                                ValueError(u"{0} is not a valid choice".format(
+                                ValueError(u"{0!r} is not a valid choice".format(
                                     value)), bundle_errors)
 
                     if name in request.unparsed_arguments:


### PR DESCRIPTION
When a string argument with choices gets an illegal value, make the error message clearer:
"USERSTRING is not a valid choice" -> "'USERSTRING' is not a valid choice"

When the string choices are normal English words, sometimes the former form is confusing. For example, if the argument value is 'your choice', the resulting message is "your choice is not a valid choice", which looks vague.
